### PR TITLE
fix: improve formatting rules

### DIFF
--- a/.changeset/cyan-bats-peel.md
+++ b/.changeset/cyan-bats-peel.md
@@ -1,0 +1,5 @@
+---
+"sv-strip": patch
+---
+
+fix: Improve formatting rules during removal to prevent unneccessary new lines at the end of script tags.

--- a/package.json
+++ b/package.json
@@ -14,13 +14,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/sv-strip/issues"
 	},
-	"keywords": [
-		"svelte",
-		"strip",
-		"types",
-		"typescript",
-		"javascript"
-	],
+	"keywords": ["svelte", "strip", "types", "typescript", "javascript"],
 	"packageManager": "pnpm@10.4.1",
 	"type": "module",
 	"scripts": {
@@ -32,9 +26,7 @@
 		"changeset": "changeset",
 		"ci:release": "unbuild && changeset publish"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"exports": {
 		".": {
 			"import": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,24 +205,41 @@ function removeNode(src: MagicString, start: number, end: number, format: boolea
 	let newEnd = end;
 
 	if (format) {
-		newStart = 0;
-
-		// remove whitespace proceeding the node until the next newline / none whitespace character
-		for (let i = start - 1; i > -1; i--) {
-			if (/\S|\n/.test(src.original[i])) {
-				newStart = i + 1;
-				break;
-			}
-		}
+		let isLast = false;
 
 		// remove whitespace beyond the node until the proceeding whitespace of the next node
 		for (let i = end; i < src.original.length; i++) {
 			if (/\S/.test(src.original[i])) {
+				if (src.original[i] === '<' && src.original.slice(i).startsWith('</script')) {
+					isLast = true;
+					// back up 1 character so that the last node isn't on the same line as the script
+					newEnd -= 1;
+				}
 				break;
 			}
 
 			if (src.original[i] === '\n') {
 				newEnd = i + 1;
+			}
+		}
+
+		newStart = 0;
+
+		// remove whitespace proceeding the node until the next newline / none whitespace character
+		for (let i = start - 1; i > -1; i--) {
+			let regex: RegExp;
+
+			// if we are last then we get rid of all whitespace trailing the previous node
+			if (isLast) {
+				regex = new RegExp(/\S/);
+			} else {
+				// else we only remove to the new line
+				regex = new RegExp(/\S|\n/);
+			}
+
+			if (regex.test(src.original[i])) {
+				newStart = i + 1;
+				break;
 			}
 		}
 	}

--- a/tests/cases/correctly-formats-script/js.svelte
+++ b/tests/cases/correctly-formats-script/js.svelte
@@ -1,0 +1,3 @@
+<script module>
+    export const foo = 5;
+</script>

--- a/tests/cases/correctly-formats-script/ts.svelte
+++ b/tests/cases/correctly-formats-script/ts.svelte
@@ -1,0 +1,7 @@
+<script lang="ts" module>
+    type Foo = number;
+    
+    export const foo: Foo = 5;
+
+    type Bar = string;
+</script>


### PR DESCRIPTION
Previously this:
```svelte
<script lang="ts" module>
    type Foo = number;
    
    export const foo: Foo = 5;
    type Bar = string;
</script>
```

would become this:

```svelte
<script module>
    export const foo = 5;

</script>
```

now it becomes this:
```svelte
<script module>
    export const foo = 5;
</script>
```